### PR TITLE
Add full Bowtie2 index and reference FASTA for host contamination testing

### DIFF
--- a/polybio/host/bowtie2_index/hg38.1.bt2
+++ b/polybio/host/bowtie2_index/hg38.1.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:238f60f5063420401e49a9cce204321d856774ca6c8528c0231ac032c9fe99e8
+size 904891988

--- a/polybio/host/bowtie2_index/hg38.2.bt2
+++ b/polybio/host/bowtie2_index/hg38.2.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2accf52b4519d7f1cd8dcf6e622eb09c219b414152243fa3b71edcf93636de
+size 675522192

--- a/polybio/host/bowtie2_index/hg38.3.bt2
+++ b/polybio/host/bowtie2_index/hg38.3.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f6d3b397a0d4ad1f631a3d38a83203ac63aaaa04b588c9ca97b2bf28e5312ff
+size 179

--- a/polybio/host/bowtie2_index/hg38.4.bt2
+++ b/polybio/host/bowtie2_index/hg38.4.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9685bc82846400472f619e42e9e0a0b29903bc087053a97ef3eb200585a1f4c8
+size 675522186

--- a/polybio/host/bowtie2_index/hg38.rev.1.bt2
+++ b/polybio/host/bowtie2_index/hg38.rev.1.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f4cb510b42b3ba817a043617aafad67361a52a8aa994445f9c9d438b6c68ad
+size 904891988

--- a/polybio/host/bowtie2_index/hg38.rev.2.bt2
+++ b/polybio/host/bowtie2_index/hg38.rev.2.bt2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d6aaa979e69ebf717bd4aa62edcf457a703fea5f3b64b2177d44b80a99718e2
+size 675522192

--- a/polybio/ncbi_genome/ncbi_dataset/data/GCA_009914755.4/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna
+++ b/polybio/ncbi_genome/ncbi_dataset/data/GCA_009914755.4/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1643186db3c77afee2aa7f492f15f7c52416b5bbdb2b70c0cddf024378b930c
+size 2735865856


### PR DESCRIPTION
This PR adds the necessary files to support nf-test testing of the `bowtie2_align` module with the PolyBio dataset. Specifically, it includes:

- A full Bowtie2 index (`hg38.*.bt2` files) for the human genome.
- The matching reference FASTA file (`GCA_009914755.4_T2T-CHM13v2.0_genomic.fna`).

These files were added in accordance with nf-core guidelines for test datasets.

### Purpose

These additions will allow us to:
- Perform host contamination filtering tests using real paired-end FASTQ data.
- Validate the functionality of the `bowtie2_align` module using human reference genome alignment.

### Notes

- Files are hosted under `polybio/host/` and `polybio/ncbi_genome/` to maintain organization.
- The FASTA and index files match and were sourced from NCBI (T2T-CHM13v2.0).
- Large files were pushed in batches to avoid timeouts.